### PR TITLE
V 0.71 : Modif contrôle MD5

### DIFF
--- a/sources/debian/changelog
+++ b/sources/debian/changelog
@@ -1,9 +1,14 @@
-se3-wpkg (0.70~1) unstable; urgency=low
+se3-wpkg (0.71) unstable; urgency=low
+
+  * MD5 ignoré pour les fichiers d'installation
+
+ -- Antoine Labarussias <antoineone01@gmail.com>  Thu, 02 Mar 2017 13:31:42 +0200
+ 
+ se3-wpkg (0.70~1) unstable; urgency=low
 
   * Affichage du nom de l'application et de la categorie sur la page du svn
 
  -- Laurent Joly <laurentjoly@orange.fr>  Mon, 13 Feb 2017 23:55:30 +0200
-
 
 se3-wpkg (0.67) unstable; urgency=low
 

--- a/sources/www/bin/installPackage.sh
+++ b/sources/www/bin/installPackage.sh
@@ -19,6 +19,7 @@ function Download () {
 	local destFile="$2"
 	local MD5="$3"
 	local pasDeDownload="$4"
+	local ignoreMD5="$5"
 	# $Appli est défini avec l'id de l'Appli
 	echo ""
 	
@@ -26,15 +27,19 @@ function Download () {
 		if [ -e "$Z/$destFile" ]; then
 			echo -e "    Le fichier '$Z/$destFile' est présent.\n"
 			PassMD5="1"
-			if [ "$MD5" != "" ]; then
-				if ( md5sum "$Z/$destFile" | grep $MD5 ) ; then
-					echo -e "Le fichier présent est valide (MD5=$MD5).\n";
-				else
-					md5sum "$Z/$destFile"
-					echo -e "  Erreur : le test md5sum ($MD5) a échoué.\n"
-					ErreurApp="13"
-					PassMD5="0"
-				fi
+			if [ "$ignoreMD5" == "1" ]; then
+			    echo -e "Pas de contrôle MD5 (MD5=$MD5).\n";
+			else
+			    if [ "$MD5" != "" ]; then
+				    if ( md5sum "$Z/$destFile" | grep $MD5 ) ; then
+				    	echo -e "Le fichier présent est valide (MD5=$MD5).\n";
+				    else
+				    	md5sum "$Z/$destFile"
+				    	echo -e "  Erreur : le test md5sum ($MD5) a échoué.\n"
+				    	ErreurApp="13"
+				    	PassMD5="0"
+				    fi
+			    fi
 			fi
 		else
 			echo "    Erreur : Le fichier '$Z/$destFile' est absent."
@@ -79,15 +84,19 @@ function Download () {
 						ErreurApp="12"
 					else
 						PassMD5="1"
-						if [ "$MD5" != "" ]; then
-							if ( md5sum "$fileName" | grep $MD5 ) ; then
-								echo -e "\nLe fichier téléchargé est valide (MD5=$MD5).\n";
-							else
-								md5sum "$fileName"
-								echo -e "  Erreur : le test md5sum ($MD5) a échoué.\n"
-								ErreurApp="13"
-								PassMD5="0"
-							fi
+						if [ "$ignoreMD5" == "1" ]; then
+							echo -e "Pas de contrôle MD5 (MD5=$MD5).\n";
+						else
+						    if [ "$MD5" != "" ]; then
+							    if ( md5sum "$fileName" | grep $MD5 ) ; then
+								    echo -e "\nLe fichier téléchargé est valide (MD5=$MD5).\n";
+							    else
+								    md5sum "$fileName"
+								    echo -e "  Erreur : le test md5sum ($MD5) a échoué.\n"
+							    	ErreurApp="13"
+							    	PassMD5="0"
+							    fi
+						    fi
 						fi
 						if [ "$PassMD5" == "1" ] ; then
 							if ( mv "$fileName" "$Z/$destFile" ) ;then

--- a/sources/www/bin/installPackage.xsl
+++ b/sources/www/bin/installPackage.xsl
@@ -51,13 +51,13 @@
 						<xsl:when test="$nDownloadAppli > 1" >
 							<xsl:text>    echo &quot;    &apos;</xsl:text><xsl:value-of select="@name"/><xsl:text>&apos; (Rev: </xsl:text><xsl:value-of select="@revision"/><xsl:text>) a besoin de </xsl:text><xsl:value-of select="$nDownloadAppli"/><xsl:text> fichiers téléchargés.&quot;&#x00a;</xsl:text>
 							<xsl:for-each select="download">
-								<xsl:text>      Download &apos;</xsl:text><xsl:value-of select="@url"/><xsl:text>&apos; &apos;</xsl:text><xsl:value-of select="@saveto"/><xsl:text>&apos; &apos;</xsl:text><xsl:value-of select="@md5sum"/><xsl:text>&apos; &apos;</xsl:text><xsl:value-of select="$NoDownload"/><xsl:text>&apos; &#x00a;</xsl:text>
+								<xsl:text>      Download &apos;</xsl:text><xsl:value-of select="@url"/><xsl:text>&apos; &apos;</xsl:text><xsl:value-of select="@saveto"/><xsl:text>&apos; &apos;</xsl:text><xsl:value-of select="@md5sum"/><xsl:text>&apos; &apos;</xsl:text><xsl:value-of select="$NoDownload"/><xsl:text>&apos; &apos;</xsl:text><xsl:choose><xsl:when test="$controlMD5 = ''"><xsl:text>1</xsl:text></xsl:when></xsl:choose><xsl:text>&apos; &#x00a;</xsl:text>
 							</xsl:for-each>
 						</xsl:when>
 						<xsl:when test="$nDownloadAppli = 1" >
 							<xsl:text>    echo &quot;    &apos;</xsl:text><xsl:value-of select="@name"/><xsl:text>&apos; (Rev: </xsl:text><xsl:value-of select="@revision"/><xsl:text>) a besoin d'1 fichier téléchargé.&quot;&#x00a;</xsl:text>
 							<xsl:for-each select="download">
-								<xsl:text>      Download &apos;</xsl:text><xsl:value-of select="@url"/><xsl:text>&apos; &apos;</xsl:text><xsl:value-of select="@saveto"/><xsl:text>&apos; &apos;</xsl:text><xsl:value-of select="@md5sum"/><xsl:text>&apos; &apos;</xsl:text><xsl:value-of select="$NoDownload"/><xsl:text>&apos; &#x00a;</xsl:text>
+								<xsl:text>      Download &apos;</xsl:text><xsl:value-of select="@url"/><xsl:text>&apos; &apos;</xsl:text><xsl:value-of select="@saveto"/><xsl:text>&apos; &apos;</xsl:text><xsl:value-of select="@md5sum"/><xsl:text>&apos; &apos;</xsl:text><xsl:value-of select="$NoDownload"/><xsl:text>&apos; &apos;</xsl:text><xsl:choose><xsl:when test="$controlMD5 = ''"><xsl:text>1</xsl:text></xsl:when></xsl:choose><xsl:text>&apos; &#x00a;</xsl:text>
 							</xsl:for-each>
 						</xsl:when>
 						<xsl:when test="$nDownloadAppli = 0" >


### PR DESCRIPTION
Possibilité d'ignorer le contrôle md5 des fichiers d'installation en plus du xml déjà existant